### PR TITLE
🧹 Fix `describe()` name in test for `LintAnalyzer`

### DIFF
--- a/tests/__tests__/LintAnalyzer.js
+++ b/tests/__tests__/LintAnalyzer.js
@@ -223,7 +223,7 @@ describe('LintAnalyzer', () => {
       })
     })
 
-    describe('to be instance of LintAnalyzer', () => {
+    describe('to call constructor', () => {
       /** @type {Array<Object>} */
       const cases = [
         {


### PR DESCRIPTION
## Why

* Close #102

