### PR TITLE
🧹 Fix lint of `jsdoc/check-types` about `Object` to `object`

### DIFF
--- a/tests/__tests__/ESLintInspector.js
+++ b/tests/__tests__/ESLintInspector.js
@@ -27,7 +27,7 @@ describe('ESLintInspector', () => {
   describe('constructor', () => {
     describe('to keep property', () => {
       describe('#analyzers', () => {
-        /** @type {Array<Object>} */
+        /** @type {Array<object>} */
         const cases = [
           {
             params: {
@@ -133,7 +133,7 @@ describe('ESLintInspector', () => {
 describe('ESLintInspector', () => {
   describe('.create()', () => {
     describe('to return instance of', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -234,7 +234,7 @@ describe('ESLintInspector', () => {
     })
 
     describe('to call constructor', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {

--- a/tests/__tests__/FileLintAnalyzer.js
+++ b/tests/__tests__/FileLintAnalyzer.js
@@ -19,7 +19,7 @@ describe('FileLintAnalyzer', () => {
 describe('FileLintAnalyzer', () => {
   describe('.create()', () => {
     describe('to be instance of FileLintAnalyzer', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -111,7 +111,7 @@ describe('FileLintAnalyzer', () => {
     })
 
     describe('to call constructor', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -292,7 +292,7 @@ describe('FileLintAnalyzer', () => {
 describe('FileLintAnalyzer', () => {
   describe('.extractLintKeys()', () => {
     describe('as standard rule', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -368,7 +368,7 @@ describe('FileLintAnalyzer', () => {
     })
 
     describe('as plugin rule', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {

--- a/tests/__tests__/LintAnalyzer.js
+++ b/tests/__tests__/LintAnalyzer.js
@@ -8,7 +8,7 @@ const LintAnalyzer = require('../../lib/LintAnalyzer')
 describe('LintAnalyzer', () => {
   describe('constructor', () => {
     describe('to keep property', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -130,7 +130,7 @@ describe('LintAnalyzer', () => {
 describe('LintAnalyzer', () => {
   describe('.create()', () => {
     describe('to be instance of LintAnalyzer', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -224,7 +224,7 @@ describe('LintAnalyzer', () => {
     })
 
     describe('to call constructor', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -328,7 +328,7 @@ describe('LintAnalyzer', () => {
 describe('LintAnalyzer', () => {
   describe('#getHitLintMessages()', () => {
     describe('with ruleId only', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -457,7 +457,7 @@ describe('LintAnalyzer', () => {
     })
 
     describe('with ruleId and message', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -522,7 +522,7 @@ describe('LintAnalyzer', () => {
   describe('#getUnexpectedLintMessages()', () => {
     describe('with ruleId only', () => {
       describe('with expected message', () => {
-        /** @type {Array<Object>} */
+        /** @type {Array<object>} */
         const cases = [
           {
             params: {
@@ -666,7 +666,7 @@ describe('LintAnalyzer', () => {
       })
 
       describe('without expected message', () => {
-        /** @type {Array<Object>} */
+        /** @type {Array<object>} */
         const cases = [
           {
             params: {
@@ -750,7 +750,7 @@ describe('LintAnalyzer', () => {
 
     describe('with ruleId and message', () => {
       describe('with expected message', () => {
-        /** @type {Array<Object>} */
+        /** @type {Array<object>} */
         const cases = [
           {
             params: {
@@ -815,7 +815,7 @@ describe('LintAnalyzer', () => {
 describe('LintAnalyzer', () => {
   describe('#worksAsExpected()', () => {
     describe('to be truthy', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -895,7 +895,7 @@ describe('LintAnalyzer', () => {
     })
 
     describe('to be falsy', () => {
-      /** @type {Array<Object>} */
+      /** @type {Array<object>} */
       const cases = [
         {
           params: {
@@ -1042,7 +1042,7 @@ describe('LintAnalyzer', () => {
   describe('#getUnexpectedLint()', () => {
     describe('with ruleId only', () => {
       describe('has hit messages', () => {
-        /** @type {Array<Object>} */
+        /** @type {Array<object>} */
         const cases = [
           {
             params: {
@@ -1139,7 +1139,7 @@ describe('LintAnalyzer', () => {
       })
 
       describe('has no hit messages', () => {
-        /** @type {Array<Object>} */
+        /** @type {Array<object>} */
         const cases = [
           {
             params: {
@@ -1228,7 +1228,7 @@ describe('LintAnalyzer', () => {
 
     describe('with ruleId and message', () => {
       describe('has hit messages', () => {
-        /** @type {Array<Object>} */
+        /** @type {Array<object>} */
         const cases = [
           {
             params: {
@@ -1287,7 +1287,7 @@ describe('LintAnalyzer', () => {
       })
 
       describe('has no hit messages', () => {
-        /** @type {Array<Object>} */
+        /** @type {Array<object>} */
         const cases = [
           {
             params: {


### PR DESCRIPTION
## Why

* Close #198
