### PR TITLE
🧹 Fix lint of `prefer-const`

### DIFF
--- a/tests/intents/expected/standard/no-restricted-syntax/noLet.js
+++ b/tests/intents/expected/standard/no-restricted-syntax/noLet.js
@@ -1,5 +1,6 @@
 'use strict'
 
 let alpha = 999
+alpha += 100
 
 module.exports = alpha


### PR DESCRIPTION
## Why

* Close #202

## How

* To avoid `prefer-const` lint error by `eslint-config-openreachtech@2.0.0`
