### PR TITLE
🧹 Fix lint error of `jsdoc/match-description`

### DIFF
--- a/lib/LintAnalyzer.js
+++ b/lib/LintAnalyzer.js
@@ -79,7 +79,7 @@ class LintAnalyzer {
   }
 
   /**
-   * get: unexpected messages.
+   * Get unexpected lint messages.
    *
    * @returns {Array<import('eslint').Linter.LintMessage>} - Unexpected messages.
    */


### PR DESCRIPTION
## Why

* Close #210 
