### PR TITLE
🐛 Fix typo `describe()` name of `LintKeyExtractor#extractMessageId()`

### DIFF
--- a/tests/__tests__/tools/LintKeyExtractor.js
+++ b/tests/__tests__/tools/LintKeyExtractor.js
@@ -440,7 +440,7 @@ describe('LintKeyExtractor', () => {
 })
 
 describe('LintKeyExtractor', () => {
-  describe('#get:messageId', () => {
+  describe('#extractMessageId()', () => {
     describe('with ruleId only', () => {
       const cases = [
         {


### PR DESCRIPTION
## Why

* Close #266
