### PR TITLE
🐛 Typo file name of Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,6 @@ module.exports = {
     '@openreachtech/renchan-test-tools/lib/environment/setupAfterEnv.js',
   ],
   testPathIgnorePatterns: [
-    '/node_modules/',
+    '<rootDir>/node_modules/',
   ],
 }


### PR DESCRIPTION
## Why

* Close #305

## How

* Fix typo file name `jest.confg.js` → `jest.config.js`
* Add `<rootDir>` to path of `testPathIgnorePatterns`
